### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,10 @@
 site_name: Thinking Cities
 site_url: https://github.com/telefonicaid/thinking-cities/
-repo_url: https://github.com/telefonicaid/thinking-cities.git
+repo_url: https://github.com/telefonicaid/thinking-cities
 site_description: IoT Platform document site
 docs_dir: docs/
 site_dir: html
+edit_uri: edit/master/docs/
 markdown_extensions: [toc,tables, fenced_code]
 extra_css: ["telefonica.css" ]
 use_directory_urls: false


### PR DESCRIPTION
Adding the right config parameter, according to mkdocs instructions will fix documentation broken links:
https://www.mkdocs.org/user-guide/configuration/#edit_uri
The same fix has been applied successfully in other similar repositories:
telefonicaid/fiware-orion#3491
Also this must be changed:
Repo URL must be:
repo_url: https://github.com/telefonicaid/thinking-cities
Instead of
repo_url: https://github.com/telefonicaid/thinking-cities.git